### PR TITLE
altera config do gráfico

### DIFF
--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -47,7 +47,7 @@ export class DashboardComponent implements OnInit {
         datasets: [
           {
             label: 'Valor das doações',
-            data: data.values,
+            data: values,
             backgroundColor: 'green'
 
           }


### PR DESCRIPTION
This pull request includes a minor update to the `DashboardComponent` in the `dashboard.component.ts` file. The change simplifies the code by renaming the `data.values` property to `values` in the dataset configuration.

* [`src/app/features/dashboard/dashboard.component.ts`](diffhunk://#diff-7b775d4c64cbb7e650f88f6d17bec954be6c71b4b7e46a138de005a8715cb3d7L50-R50): Updated the `data` property in the dataset configuration to use `values` directly instead of `data.values`.