### PR TITLE
adiciona campo de input variavel de acordo com tipo do grafico

### DIFF
--- a/src/app/features/report-generate/report-generate.component.css
+++ b/src/app/features/report-generate/report-generate.component.css
@@ -20,7 +20,8 @@ label {
 }
 
 select,
-input[type="date"] {
+input[type="date"],
+input[type="number"]{
     width: 100%;
     padding: 12px 16px;
     border-radius: 24px;

--- a/src/app/features/report-generate/report-generate.component.html
+++ b/src/app/features/report-generate/report-generate.component.html
@@ -7,18 +7,27 @@
     <option value="por-mes">Total arrecadado por mês</option>
   </select>
 
-  <label for="data-inicio">Data início</label>
-  <input type="date" id="data-inicio" name="dataInicio" [(ngModel)]="dataInicio" required />
+  <!-- Campos para relatórios que NÃO são "por-mes" -->
+  <ng-container *ngIf="tipoRelatorio !== 'por-mes'">
+    <label for="data-inicio">Data início</label>
+    <input type="date" id="data-inicio" name="dataInicio" [(ngModel)]="dataInicio" required />
 
-  <label for="data-fim">Data fim</label>
-  <input type="date" id="data-fim" name="dataFim" [(ngModel)]="dataFim" required />
+    <label for="data-fim">Data fim</label>
+    <input type="date" id="data-fim" name="dataFim" [(ngModel)]="dataFim" required />
 
-  <label for="tipo-parceiro">Parceiro:</label>
-  <select id="parceiro" name="parceiro" [(ngModel)]="parceiro" required>
-    <option value="" disabled>Selecione um parceiro</option>
-    <option value="todos">Todos</option>
-    <option *ngFor="let p of parceiros" [value]="p.nome">{{ p.nome }}</option>
-  </select>
+    <label for="tipo-parceiro">Parceiro:</label>
+    <select id="parceiro" name="parceiro" [(ngModel)]="parceiro" required>
+      <option value="" disabled>Selecione um parceiro</option>
+      <option value="todos">Todos</option>
+      <option *ngFor="let p of parceiros" [value]="p.nome">{{ p.nome }}</option>
+    </select>
+  </ng-container>
+
+  <!-- Campo "Ano Base" apenas para "por-mes" -->
+  <ng-container *ngIf="tipoRelatorio === 'por-mes'">
+    <label for="ano-base">Ano base:</label>
+    <input type="number" id="ano-base" name="anoBase" [(ngModel)]="anoBase" required min="2000" max="2100" />
+  </ng-container>
 
   <button type="submit" class="report-btn">Gerar Relatório</button>
 </form>

--- a/src/app/features/report-generate/report-generate.component.ts
+++ b/src/app/features/report-generate/report-generate.component.ts
@@ -14,7 +14,7 @@ import { ParceirosService } from '../config/services/parceiros.service';
 export class ReportGenerateComponent implements OnInit {
 
   parceiros: any[] = [];
-
+  anoBase = '';
   tipoRelatorio = '';
   dataInicio = '';
   dataFim = '';
@@ -37,7 +37,7 @@ export class ReportGenerateComponent implements OnInit {
   gerarRelatorio() {
     this.router.navigate(['/gerar-relatorio'], {
       queryParams: {
-        anoMensal: "2024",
+        anoMensal: this.anoBase,
         tipo: this.tipoRelatorio,
         inicio: this.dataInicio,
         fim: this.dataFim,


### PR DESCRIPTION
This pull request introduces enhancements to the report generation feature, including support for a new "Ano Base" input field for monthly reports and conditional rendering of input fields based on report type. The changes span across the HTML, CSS, and TypeScript files of the `report-generate` component.

### Enhancements to report generation functionality:

* **Conditional rendering of input fields based on report type**:
  - Updated `src/app/features/report-generate/report-generate.component.html` to include conditional rendering for "Ano Base" input when the report type is "por-mes" and other fields when the report type is not "por-mes". [[1]](diffhunk://#diff-c041b0630bd5bb4d17344f62cc1b5646a0a9b3a26cf19185ad0c39c6f71ae076R10-R11) [[2]](diffhunk://#diff-c041b0630bd5bb4d17344f62cc1b5646a0a9b3a26cf19185ad0c39c6f71ae076R24-R30)

* **Addition of "Ano Base" input field**:
  - Added an `input[type="number"]` field for "Ano Base" in the HTML file with validation for minimum and maximum values. Corresponding CSS styles were updated to support `input[type="number"]`. [[1]](diffhunk://#diff-4a72d3af9abe54fe86d30616d9e4d2614fe3a86e034e6caf7d460c961eab339eL23-R24) [[2]](diffhunk://#diff-c041b0630bd5bb4d17344f62cc1b5646a0a9b3a26cf19185ad0c39c6f71ae076R24-R30)

### Updates to TypeScript logic:

* **Integration of "Ano Base" into report generation**:
  - Added `anoBase` property to the `ReportGenerateComponent` class and updated the `gerarRelatorio` method to use `anoBase` dynamically instead of hardcoding the year. [[1]](diffhunk://#diff-a4a3e830bd48b17325c75071459f53ce1a4b172f02b83ac9454a9f3746df0492L17-R17) [[2]](diffhunk://#diff-a4a3e830bd48b17325c75071459f53ce1a4b172f02b83ac9454a9f3746df0492L40-R40)